### PR TITLE
Logging type should be "slf4j" not "sl4j".

### DIFF
--- a/src/main/resources/META-INF/spring/ticketRegistry.xml
+++ b/src/main/resources/META-INF/spring/ticketRegistry.xml
@@ -11,7 +11,7 @@
             <bean class="com.hazelcast.config.Config">
                 <property name="properties">
                     <util:properties>
-                        <prop key="hazelcast.logging.type">sl4j</prop>
+                        <prop key="hazelcast.logging.type">slf4j</prop>
                         <prop key="hazelcast.max.no.heartbeat.seconds">5</prop>
                     </util:properties>
                 </property>


### PR DESCRIPTION
According to http://docs.hazelcast.org/docs/latest/manual/html/logging.html, the logging type should be "slf4j", with the existing configuration, log configuration is generally ignored and logs simply go to the console and/or catalina.out.
